### PR TITLE
Update for Immutant 2.0.0-beta2.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject demo "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                  [org.immutant/web "2.0.0-beta1"]
+                  [org.immutant/web "2.0.0-beta2"]
                   [compojure "1.1.8"]
                   [ring/ring-core "1.3.0"]
                   [environ "1.0.0"]]

--- a/src/demo/core.clj
+++ b/src/demo/core.clj
@@ -1,7 +1,7 @@
 (ns demo.core
   (:require
     [immutant.web             :as web]
-    [immutant.web.websocket   :as ws]
+    [immutant.web.async       :as async]
     [immutant.web.middleware  :as web-middleware]
     [compojure.route          :as route]
     [environ.core             :refer (env)]
@@ -11,12 +11,12 @@
 
 (def websocket-callbacks
   "WebSocket callback functions"
-  {:on-open    (fn [channel handshake]
-    (ws/send! channel "Ready to reverse your messages!"))
+  {:on-open    (fn [channel]
+    (async/send! channel "Ready to reverse your messages!"))
   :on-close   (fn [channel {:keys [code reason]}]
     (println "close code:" code "reason:" reason))
   :on-message (fn [ch m]
-    (ws/send! ch (apply str (reverse m))))})
+    (async/send! ch (apply str (reverse m))))})
 
 (defroutes routes
   (GET "/" {c :context} (redirect (str c "/index.html")))
@@ -28,6 +28,6 @@
       (web-middleware/wrap-session {:timeout 20})
       ;; wrap the handler with websocket support
       ;; websocket requests will go to the callbacks, ring requests to the handler
-      (ws/wrap-websocket websocket-callbacks))
-      (merge {"host" (env :demo-web-host), "port" (env :demo-web-port)}
+      (web-middleware/wrap-websocket websocket-callbacks))
+    (merge {"host" (env :demo-web-host), "port" (env :demo-web-port)}
       args)))


### PR DESCRIPTION
Beta2 introduced the as-channel function to support websockets and HTTP
streaming, and all of immutant.web.websockets was moved to
immutant.web.async (except for the wrap-websocket middleware, which
still exists in immutant.web.middleware).

This demonstrates usage of as-channel, as it's now the preferred way to
handle websockets.
